### PR TITLE
Add basic layout for Doubt Sharing Platform

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@material-ui/core": "^4.11.3",
+    "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^4.0.0-alpha.57",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
-    "@material-ui/lab": "^4.0.0-alpha.57",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,3 +1,17 @@
+::-webkit-scrollbar {
+  width: 10px;
+}
+::-webkit-scrollbar-track {
+  box-shadow: inset 0 0 5px grey; 
+  border-radius: 10px;
+}
+::-webkit-scrollbar-thumb {
+  background: grey; 
+  border-radius: 10px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: darkgrey; 
+}
 .App {
   text-align: center;
 }
@@ -7,6 +21,18 @@
   pointer-events: none;
 }
 
+.pd {
+  padding: 30px;
+}
+
+.mt {
+  margin-top: 100px;
+}
+
+.margin {
+  margin-right: 20px;
+}
+
 @media (prefers-reduced-motion: no-preference) {
   .App-logo {
     animation: App-logo-spin infinite 20s linear;
@@ -14,13 +40,10 @@
 }
 
 .App-header {
-  background-color: #282c34;
-  min-height: 100vh;
+  background-color: #ffab73;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
   color: white;
 }
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,23 +1,15 @@
-import logo from './logo.svg';
+//import logo from './logo.svg';
 import './App.css';
+import Header from './components/header';
+import Doubt from './components/doubt_sharing';
+import Footer from './components/footer';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+    <div>
+      <Header></Header>
+      <Doubt></Doubt>
+      <Footer></Footer>
     </div>
   );
 }

--- a/client/src/components/card.js
+++ b/client/src/components/card.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import {makeStyles} from '@material-ui/core/styles';
+import Card from '@material-ui/core/Card';
+import CardHeader from '@material-ui/core/CardHeader';
+import CardContent from '@material-ui/core/CardContent';
+import Avatar from '@material-ui/core/Avatar';
+// import {Data} from './dummy_data';
+
+const useStyles = makeStyles({
+    justify: {
+        textAlign: 'justify',
+    }
+});
+
+export default function CardTemplate(props) {
+    const classes = useStyles();
+    return (
+        <Card className={props.className}>
+            <CardHeader avatar={<Avatar>D</Avatar>} title={props.author+"  ~  "+props.type} subheader="20 February 2021"></CardHeader>
+            <CardContent>
+                <p className={classes.justify}>{props.description}</p>
+            </CardContent>
+        </Card>
+    )
+}

--- a/client/src/components/doubt_plate.js
+++ b/client/src/components/doubt_plate.js
@@ -1,0 +1,60 @@
+import React, {useState} from 'react';
+import {makeStyles} from '@material-ui/core/styles';
+import TextField from '@material-ui/core/TextField';
+import Button from '@material-ui/core/Button';
+import {Data} from './dummy_data';
+import Card from './card';
+
+const useStyles = makeStyles({
+    button: {
+        backgroundColor: "green",
+        color: "white",
+        '&:hover': {
+            backgroundColor: "green",
+            color: "white",
+            opacity: "0.9"
+        },
+    },
+    mb: {
+        marginBottom: "30px",
+    },
+});
+
+export default function Chat(props) {
+    const classes = useStyles();
+    const [input, setInput] = useState("");
+    const [data, setData] = useState(Data.questions);
+    function handleChange(event) {
+        var value = event.target.value;
+        setInput(value);
+    }
+    function handleClick() {
+        var updatedData = data;
+        var update = {
+            author: "XXX",
+            comment: input
+        };
+        updatedData[0].comments.push(update);
+        setInput("");
+        setData(updatedData);
+    }
+    return (
+        <div className="pd">
+            {data.map((question, index) => {
+                return (
+                    <div key={index}>
+                        <h2>{question.title}</h2>
+                        <Card className={classes.mb} key={question._id} author={question.author} description={question.description} type="Question Description"></Card>
+                        {question.comments.map((comment, index) => {
+                            return <Card className={classes.mb} key={index} author={comment.author} description={comment.comment} type="Answer"></Card>;
+                        })}                    
+                    </div>
+                );
+            })}
+            <form className="pd mt">
+                <TextField variant="filled" className={classes.mb} fullWidth multiline rowsMax={4} value={input} placeholder="Add your comment ..." onChange={handleChange}></TextField>
+                <Button variant="contained" className={classes.button} onClick={handleClick}>Submit</Button>
+            </form>
+        </div>       
+    );
+}

--- a/client/src/components/doubt_sharing.js
+++ b/client/src/components/doubt_sharing.js
@@ -1,0 +1,24 @@
+import React from 'react';
+// import {makeStyles} from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+// import Paper from '@material-ui/core/Paper';
+import Chat from './doubt_plate';
+
+// const useStyles = makeStyles({
+
+// });
+
+export default function Doubt(props) {
+    return (
+        <div>
+            <Grid container>
+                {/* <Grid item xs={2}>
+                    <Paper className={classes.sideGrids}>item</Paper>
+                </Grid> */}
+                <Grid item>
+                    <Chat></Chat>
+                </Grid>
+            </Grid>            
+        </div>
+    );
+}

--- a/client/src/components/dummy_data.js
+++ b/client/src/components/dummy_data.js
@@ -1,0 +1,25 @@
+ export const Data = {
+    questions: [
+        {
+            _id: 1,
+            title: "What is React?",
+            description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+            no_comments: 3,
+            author: "Deepesh Gupta",
+            comments: [
+                {
+                    author: "Deepesh Gupta",
+                    comment: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+                },
+                {
+                    author: "Somesh Gupta",
+                    comment: "Lorem ipsum is placeholder text commonly used in the graphic, print, and publishing industries for previewing layouts and visual mockups."
+                },
+                {
+                    author: "Pragati Gupta",
+                    comment: "The purpose of lorem ipsum is to create a natural looking block of text (sentence, paragraph, page, etc.) that doesn't distract from the layout. A practice not without controversy, laying out pages with meaningless filler text can be very useful when the focus is meant to be on design, not content."
+                }
+            ]
+        }
+    ]
+};

--- a/client/src/components/footer.js
+++ b/client/src/components/footer.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import {makeStyles} from '@material-ui/core/styles';
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+ 
+const useStyles = makeStyles({
+    footer: {
+        backgroundColor: "#ffab73",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        color: "white",
+    },
+});
+
+export default function Footer(props) {
+    const classes = useStyles();
+    return (
+        <AppBar position="static" className={classes.footer}>
+            <Toolbar>
+                <p>© CollegeAada</p>
+            </Toolbar>
+        </AppBar>   
+    );
+}

--- a/client/src/components/header.js
+++ b/client/src/components/header.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import {makeStyles} from '@material-ui/core/styles';
+import AppBar from '@material-ui/core/AppBar';
+import Avatar from '@material-ui/core/Avatar';
+import Toolbar from '@material-ui/core/Toolbar';
+
+const useStyles = makeStyles({
+    AppHeader: {
+        backgroundColor: "#ffab73",
+        display: "flex",
+        flexDirection: "column",
+        color: "white",
+    }
+}); 
+
+export default function Header(props) {
+    const classes = useStyles();
+    return (
+        <AppBar position="static" className={classes.AppHeader}>
+            <Toolbar>
+                <Avatar className="margin">C</Avatar>
+                <h1>CollegeAada</h1>
+            </Toolbar>
+        </AppBar>      
+    )
+}


### PR DESCRIPTION
**Partially resolved issue #4 **

**Description:**
This is a basic layout or a frontend template for the Doubt Sharing Platform.
The data appearing there is dummy data that can be substituted with the data fetched from the database.
Minor changes are to be made to this code to make it compatible working with the backend code.

**Features of the code:**
1. Free from errors and any problems.
2. Easy to understand.
3. Contains reusable components.

The attached screenshots show the design of the page:
![Screenshot (263)](https://user-images.githubusercontent.com/63944188/109106357-99ba9700-7755-11eb-98f0-786b13661cad.png)
![Screenshot (261)](https://user-images.githubusercontent.com/63944188/109106363-9c1cf100-7755-11eb-8ce8-42d1fd659e64.png)
