### PR TITLE
Update session_manager.js

### DIFF
--- a/client/src/components/session_manager.js
+++ b/client/src/components/session_manager.js
@@ -2,7 +2,7 @@ import Cookies from "js-cookie";
 
 function getSessionCookie() {
     const sessionCookie = Cookies.get("session");
-    if(sessionCookie) {
+    if(sessionCookie && sessionCookie != "undefined") {
         return JSON.parse(sessionCookie);
     } else {
         return undefined;


### PR DESCRIPTION
The problem with the earlier version was that when the login or signup page is accessed, the browser checks for the cookie for the login session.
If the session is not available, undefined is returned and the browser reads undefined as "undefined" causing the app to crash.

Fixes include a check of the sessionCookie to be undefined or "undefined".